### PR TITLE
Added reading Falcon Limitswitch Port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "cpp"
     id "google-test-test-suite"
-    id "edu.wpi.first.GradleRIO" version "2024.2.1"
+    id "edu.wpi.first.GradleRIO" version "2024.3.1"
 }
 
 // Define my targets (RoboRIO) and artifacts (deployable files)

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -21,6 +21,10 @@
 
 #include "Constants.h"
 #include "subsystems/DriveSubsystem.h"
+#include "subsystems/IntakeSubsystem.h"
+
+#include <frc/smartdashboard/SmartDashboard.h>
+
 
 using namespace DriveConstants;
 
@@ -62,7 +66,13 @@ RobotContainer::RobotContainer() {
       [this] { return (ApplyDeadband(-m_stick.GetZ(),0.1));}
   ));
 
+
+frc::SmartDashboard::PutData("Intake Command", &m_loadIntakeCMD);
+
+
 }
+
+
 
 void RobotContainer::ConfigureButtonBindings() {}
 

--- a/src/main/cpp/commands/LoadIntake.cpp
+++ b/src/main/cpp/commands/LoadIntake.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "commands/LoadIntake.h"
+
+LoadIntake::LoadIntake(IntakeSubsystem* intakeSubsystem)
+  : m_intakeSS(intakeSubsystem)
+ {
+  // Use addRequirements() here to declare subsystem dependencies.
+  AddRequirements(intakeSubsystem);
+  this->SetName("ExampleCommand");
+}
+
+// Called when the command is initially scheduled.
+void LoadIntake::Initialize() {
+  m_intakeSS->IntakeInwards(0.3);
+}
+
+// Called repeatedly when this Command is scheduled to run
+void LoadIntake::Execute() {
+  if (m_intakeSS->ProximitySensorOnReverseLimitConnector()) {
+    m_intakeSS->IntakeInwards(0.1);
+  }
+}
+
+// Called once the command ends or is interrupted.
+void LoadIntake::End(bool interrupted) {
+  m_intakeSS->IntakeStop();
+}
+
+// Returns true when the command should end.
+bool LoadIntake::IsFinished() {
+  return m_intakeSS->ProximitySensorOnForwardLimitConnector();
+}

--- a/src/main/cpp/subsystems/IntakeSubsystem.cpp
+++ b/src/main/cpp/subsystems/IntakeSubsystem.cpp
@@ -4,17 +4,19 @@
 
 #include "subsystems/IntakeSubsystem.h"
 #include <ctre/phoenix6/StatusSignal.hpp>
+#include <frc2/command/FunctionalCommand.h>
+
 
 IntakeSubsystem::IntakeSubsystem() = default;
 
 // This method will be called once per scheduler run
 void IntakeSubsystem::Periodic() {
-  if (ProximitySensorOnForwardLimitConnector()){
-    fmt::println("Forward Limit {}",m_intakeMotor.GetForwardLimit().ToString());
-  }
-  if (ProximitySensorOnReverseLimitConnector()){
-    fmt::println("Reverse Limit {}",m_intakeMotor.GetReverseLimit().ToString());
-  }
+ // if (ProximitySensorOnForwardLimitConnector()){
+ //   fmt::println("Forward Limit {}",m_intakeMotor.GetForwardLimit().ToString());
+ // }
+ // if (ProximitySensorOnReverseLimitConnector()){
+ //   fmt::println("Reverse Limit {}",m_intakeMotor.GetReverseLimit().ToString());
+ // }
 }
 
 void IntakeSubsystem::RotateToForward(){
@@ -39,6 +41,8 @@ void IntakeSubsystem::IntakeInwards(double IntakePower){
 
 void IntakeSubsystem::IntakeStop(){
   m_intakeMotor.Set(0.0);
+  fmt::println("Motor Rotor Position {}",m_intakeMotor.GetRotorPosition().GetValueAsDouble());
+  
 }
 
 void IntakeSubsystem::IntakeForwardUntilRollersClear(){
@@ -56,7 +60,30 @@ bool IntakeSubsystem::ProximitySensorOnReverseLimitConnector(){
   //if (LimitObject.GetValue()==ctre::phoenix6::signals::ForwardLimitValue::ClosedToGround);
   return (m_intakeMotor.GetReverseLimit().GetValue()==ctre::phoenix6::signals::ReverseLimitValue::ClosedToGround);
 }
+frc2::CommandPtr IntakeSubsystem::ExampleFullCommand(){
+  return frc2::FunctionalCommand(
+  // Reset encoders on command start //This is Command Init
+  [this] { //m_drive.ResetEncoders(); 
+          IntakeInwards(0.1);
+  },
+  // Start driving forward at the start of the command  //This is the Command PeriodicFunction
+  [this] { //m_drive.ArcadeDrive(ac::kAutoDriveSpeed, 0); 
+  },
+  // Stop driving at the end of the command  //This is the Command End Function
+  [this] (bool interrupted) { 
+    //m_drive.ArcadeDrive(0, 0); 
+        IntakeStop();
+  },
+  // End the command when the robot's driven distance exceeds the desired value  //This is the Command IsFinished
+  [this] { 
+    //return m_drive.GetAverageEncoderDistance() >= kAutoDriveDistanceInches; 
+    return ProximitySensorOnForwardLimitConnector();
+    //return false;
+    }
+  // Requires the subsystem
 
+).ToPtr();
+}
 
 frc2::CommandPtr IntakeSubsystem::IntakeFromFront(){
     return this->RunOnce(

--- a/src/main/cpp/subsystems/IntakeSubsystem.cpp
+++ b/src/main/cpp/subsystems/IntakeSubsystem.cpp
@@ -3,20 +3,67 @@
 // the WPILib BSD license file in the root directory of this project.
 
 #include "subsystems/IntakeSubsystem.h"
+#include <ctre/phoenix6/StatusSignal.hpp>
 
 IntakeSubsystem::IntakeSubsystem() = default;
 
 // This method will be called once per scheduler run
-void IntakeSubsystem::Periodic() {}
+void IntakeSubsystem::Periodic() {
+  if (ProximitySensorOnForwardLimitConnector()){
+    fmt::println("Forward Limit {}",m_intakeMotor.GetForwardLimit().ToString());
+  }
+  if (ProximitySensorOnReverseLimitConnector()){
+    fmt::println("Reverse Limit {}",m_intakeMotor.GetReverseLimit().ToString());
+  }
+}
 
-void RotateToForward(){};
-void RotateToBackwards(){};
-void RotateToLeft(){};
-void RotateToRight(){};
+void IntakeSubsystem::RotateToForward(){
+  // Code here to mnotion magic to the forward position
+};
+
+void IntakeSubsystem::RotateToBackwards(){
+    // Code here to mnotion magic to the backwards position
+};
+
+void IntakeSubsystem::RotateToLeft(){
+    // Code here to mnotion magic to the left position
+};
+
+void IntakeSubsystem::RotateToRight(){
+    // Code here to mnotion magic to the right position
+};
+
+void IntakeSubsystem::IntakeInwards(double IntakePower){
+  m_intakeMotor.Set(IntakePower);
+}
+
+void IntakeSubsystem::IntakeStop(){
+  m_intakeMotor.Set(0.0);
+}
+
+void IntakeSubsystem::IntakeForwardUntilRollersClear(){
+  //Code here to move the motor forward in position mode so that the root can move over a note without touching it.
+}
+
+bool IntakeSubsystem::ProximitySensorOnForwardLimitConnector(){
+  //ctre::phoenix6::StatusSignal LimitObject= m_intakeMotor.GetForwardLimit();
+  //if (LimitObject.GetValue()==ctre::phoenix6::signals::ForwardLimitValue::ClosedToGround);
+  return (m_intakeMotor.GetForwardLimit().GetValue()==ctre::phoenix6::signals::ForwardLimitValue::ClosedToGround);
+}
+
+bool IntakeSubsystem::ProximitySensorOnReverseLimitConnector(){
+  //ctre::phoenix6::StatusSignal LimitObject= m_intakeMotor.GetForwardLimit();
+  //if (LimitObject.GetValue()==ctre::phoenix6::signals::ForwardLimitValue::ClosedToGround);
+  return (m_intakeMotor.GetReverseLimit().GetValue()==ctre::phoenix6::signals::ReverseLimitValue::ClosedToGround);
+}
+
 
 frc2::CommandPtr IntakeSubsystem::IntakeFromFront(){
     return this->RunOnce(
-        [this] {RotateToForward(); });
+        [this] {RotateToForward(); 
+        // Run intake until loaded or cancelled
+                }
+        );
   };
 
   frc2::CommandPtr IntakeSubsystem::IntakeFromBack(){

--- a/src/main/cpp/subsystems/SwerveModule.cpp
+++ b/src/main/cpp/subsystems/SwerveModule.cpp
@@ -106,7 +106,7 @@ SwerveModule::SwerveModule(
 
   m_turningMotor.ConfigVoltageCompSaturation(11.0);
 
-  /* set the peak and nominal outputs */
+  // set the peak and nominal outputs 
   m_turningMotor.ConfigNominalOutputForward(0, kTimeoutMs);
   m_turningMotor.ConfigNominalOutputReverse(0, kTimeoutMs);
   //  m_turningMotor.ConfigPeakOutputForward(1.0, kTimeoutMs);
@@ -114,7 +114,7 @@ SwerveModule::SwerveModule(
   m_turningMotor.ConfigPeakOutputForward(0.3, kTimeoutMs);
   m_turningMotor.ConfigPeakOutputReverse(-0.3, kTimeoutMs);
 
-  /* set closed loop gains in slot0 */
+  // set closed loop gains in slot0 
   m_turningMotor.Config_kF(
       //kPIDLoopIdx, 0.1097, kTimeoutMs);  // WARNING this did have a kF of 0.1097,
       kPIDLoopIdx, 0.0, kTimeoutMs);  // was set to 0 as position mode
@@ -180,24 +180,7 @@ void SwerveModule::SetDesiredState(
   // Optimize the reference state to avoid spinning further than 90 degrees
   auto state = frc::SwerveModuleState::Optimize(
       referenceState, frc::Rotation2d(GetSwerveTurningFalconInternalRadians()));
-  /*
-    const auto state = (referenceState.speed.value() > 0.04) ?
-        frc::SwerveModuleState::Optimize(referenceState,
-    frc::Rotation2d(GetSwerveTurningFalconInternalRadians()))
-        :
-        referenceState;
-  */
-  /*
-  frc::SwerveModuleState state;
-  if (referenceState.speed.value() > 0.09) {
-    state=frc::SwerveModuleState::Optimize(referenceState,
-  frc::Rotation2d(GetSwerveTurningFalconInternalRadians()));
-    //fmt::print("OPTIMIZED angle {} speed
-  {}\n",state.angle.Degrees().value(),state.speed.value()); } else {
-    state=referenceState;
-    //fmt::print("NONOPTIMIZED angle {} speed
-  {}\n",state.angle.Degrees().value(),state.speed.value());
-  }*/
+ 
 
   // Need velocity in units per 100ms,
   double speedInMetresPerSecond = state.speed.value();
@@ -279,4 +262,6 @@ void SwerveModule::SetParkMode() {
 void SwerveModule::ReleaseParkMode() {
   m_driveMotor.SetNeutralMode(ctre::phoenix::motorcontrol::NeutralMode::Coast);
 }
+
+
 WPI_UNIGNORE_DEPRECATED

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -30,31 +30,37 @@
 
 // Global Constants
 
+static constexpr char const *RIO_CANBUS_NAME{"rio"};
+static constexpr char const *CARNIVORE_CANBUS_NAME{"Canivore1"};
+
 constexpr int kTimeoutMs = 10;
 constexpr int kPIDLoopIdx = 0;
 
 namespace DriveConstants {
 constexpr int kPigeonID = 5;
 
-// Drive Motor ID's
+// Drive Motor ID's end in 2
 constexpr int kFrontLeftDriveMotorID = 22;
 constexpr int kRearLeftDriveMotorID = 42;
 constexpr int kFrontRightDriveMotorID = 12;
 constexpr int kRearRightDriveMotorID = 32;
 
-// Turning Motor ID's
+// Turning Motor ID's end in 1
 constexpr int kFrontLeftTurningMotorID = 21;
 constexpr int kRearLeftTurningMotorID = 41;
 constexpr int kFrontRightTurningMotorID = 11;
 constexpr int kRearRightTurningMotorID = 31;
 
-// CANCoder ID's
+// CANCoder ID's end in 0
 constexpr int kFrontLeftAbsoluteTurningEncoderID = 20;
 constexpr int kRearLeftAbsoluteTurningEncoderID = 40;
 constexpr int kFrontRightAbsoluteTurningEncoderID = 10;
 constexpr int kRearRightAbsoluteTurningEncoderID = 30;
 constexpr double kTurning_kP = 0.22;
 constexpr double kDrive_kP = 0.1;
+
+
+
 
 // If you call DriveSubsystem::Drive with a different period make sure to update
 // this.
@@ -88,6 +94,18 @@ constexpr double kSteeringRatio = (60.0 / 10.0) * (50.0 / 14.0);
 constexpr auto kMaxDrivingRotation = units::radians_per_second_t(2.5);
 
 }  // namespace DriveConstants
+
+namespace IntakeConstants {
+// Intake Motor
+constexpr int kIntakeMotorCANID = 50; 
+
+}  // namespace IntakeConstants 
+
+namespace ClimbConstants {
+// Climb Motors
+constexpr int kLeftClimberMotorCANID = 61;
+constexpr int kRightClimberMotorCANID = 62;
+}  // namespace ClimbConstants
 
 namespace ModuleConstants {
 constexpr double kDriveGearRatio =

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -21,9 +21,13 @@ WPI_IGNORE_DEPRECATED
 #include <frc2/command/RunCommand.h>
 
 #include "Constants.h"
+
+// Subsystems
 #include "subsystems/DriveSubsystem.h"
 #include "subsystems/IntakeSubsystem.h"
 
+//Commands
+#include "commands/LoadIntake.h"
 #include "commands/DefaultDrive.h"
 
 /**
@@ -56,6 +60,9 @@ class RobotContainer {
   // The robot's subsystems
   DriveSubsystem m_drive;
   IntakeSubsystem m_intakeSubsystem;
+
+  // The Robot's Commands
+  LoadIntake m_loadIntakeCMD{&m_intakeSubsystem};
 
   void ConfigureButtonBindings();
 };

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -22,6 +22,7 @@ WPI_IGNORE_DEPRECATED
 
 #include "Constants.h"
 #include "subsystems/DriveSubsystem.h"
+#include "subsystems/IntakeSubsystem.h"
 
 #include "commands/DefaultDrive.h"
 
@@ -54,6 +55,7 @@ class RobotContainer {
 
   // The robot's subsystems
   DriveSubsystem m_drive;
+  IntakeSubsystem m_intakeSubsystem;
 
   void ConfigureButtonBindings();
 };

--- a/src/main/include/commands/LoadIntake.h
+++ b/src/main/include/commands/LoadIntake.h
@@ -1,0 +1,33 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <frc2/command/Command.h>
+#include <frc2/command/CommandHelper.h>
+#include "subsystems/IntakeSubsystem.h"
+
+/**
+ * An example command.
+ *
+ * <p>Note that this extends CommandHelper, rather extending Command
+ * directly; this is crucially important, or else the decorator functions in
+ * Command will *not* work!
+ */
+class LoadIntake
+    : public frc2::CommandHelper<frc2::Command, LoadIntake> {
+ public:
+  LoadIntake(IntakeSubsystem* intakeSubsystem);
+
+  void Initialize() override;
+
+  void Execute() override;
+
+  void End(bool interrupted) override;
+
+  bool IsFinished() override;
+private:
+IntakeSubsystem *m_intakeSS;
+
+};

--- a/src/main/include/subsystems/IntakeSubsystem.h
+++ b/src/main/include/subsystems/IntakeSubsystem.h
@@ -17,11 +17,19 @@ class IntakeSubsystem : public frc2::SubsystemBase {
   void RotateToLeft();
   void RotateToRight();
 
+  void IntakeInwards(double IntakePower);
+  void IntakeStop();
+
   frc2::CommandPtr IntakeFromFront();
   frc2::CommandPtr IntakeFromBack();
   frc2::CommandPtr IntakeFromLeft();
   frc2::CommandPtr IntakeFromRight();
   frc2::CommandPtr HandoverToShooter();
+
+  bool ProximitySensorOnForwardLimitConnector();
+  bool ProximitySensorOnReverseLimitConnector();
+
+  frc2::CommandPtr ExampleFullCommand();  //Example to show how a full command can be created inline
 
   /**
    * Will be called periodically whenever the CommandScheduler runs.
@@ -29,10 +37,8 @@ class IntakeSubsystem : public frc2::SubsystemBase {
   void Periodic() override;
 
  private:
-  bool ProximitySensorOnForwardLimitConnector();
-  bool ProximitySensorOnReverseLimitConnector();
-  void IntakeInwards(double IntakePower);
-  void IntakeStop();
+
+
   void IntakeForwardUntilRollersClear();
   void EjectNoteToShooter();
 

--- a/src/main/include/subsystems/IntakeSubsystem.h
+++ b/src/main/include/subsystems/IntakeSubsystem.h
@@ -5,11 +5,13 @@
 #pragma once
 #include <frc2/command/CommandPtr.h>
 #include <frc2/command/SubsystemBase.h>
+#include <ctre/phoenix6/TalonFX.hpp>
+#include "Constants.h"
 
 class IntakeSubsystem : public frc2::SubsystemBase {
  public:
   IntakeSubsystem();
-    
+   
   void RotateToForward();
   void RotateToBackwards();
   void RotateToLeft();
@@ -27,6 +29,15 @@ class IntakeSubsystem : public frc2::SubsystemBase {
   void Periodic() override;
 
  private:
+  bool ProximitySensorOnForwardLimitConnector();
+  bool ProximitySensorOnReverseLimitConnector();
+  void IntakeInwards(double IntakePower);
+  void IntakeStop();
+  void IntakeForwardUntilRollersClear();
+  void EjectNoteToShooter();
+
+ ctre::phoenix6::hardware::TalonFX m_intakeMotor{IntakeConstants::kIntakeMotorCANID,RIO_CANBUS_NAME};
+
   // Components (e.g. motor controllers and sensors) should generally be
   // declared private and exposed only through public methods.
 };


### PR DESCRIPTION
Hey,
I added a bit of code to the repo to start building up the intake subsystem code.  I couldn't commit it to your repo, so I had to fork the repo to my account and now I'm raising this pull request to bring those changes into your repo.  Initially I'm just trying to read the status of the limit switches connected to the Falcon motor on the intake.  Ultimately this will give us the ability to know where the note is inside the intake.  I'm proposing to have two proximity sensors connected to the forward and reverse limit ports on the falcon motor that is driving the intake.  The reason I'm trying to use these connections is so that we have less wires that are being twisted up as the intake rotates.

I'm hoping that all we will need, is power to the Falcon Motor that drive the intake rollers, another smaller power wire to power the the proximity sensors, and a CAN Wire that we can query the limit switch ports over and control the intake motor.  I'm trying to avoid running multiple sensor wires back to the RoboRIO Digital IO ports.